### PR TITLE
Breadcrumbs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     }],
     "require": {
         "php": ">=5.5",
-        "bugsnag/bugsnag": "^3.0",
+        "bugsnag/bugsnag": "^3.2",
         "psr/log": "^1.0"
     },
     "require-dev": {

--- a/tests/BugsnagLoggerTest.php
+++ b/tests/BugsnagLoggerTest.php
@@ -13,20 +13,22 @@ class BugsnagLoggerTest extends TestCase
 {
     use MockeryTrait;
 
-    public function testCanLog()
+    public function testError()
     {
         $logger = new BugsnagLogger($client = Mockery::mock(Client::class));
 
         $client->shouldReceive('notifyException')->once();
+        $client->shouldNotReceive('leaveBreadcrumb');
 
         $logger->log('error', new Exception());
     }
 
-    public function testCanSkip()
+    public function testDebug()
     {
         $logger = new BugsnagLogger($client = Mockery::mock(Client::class));
 
         $client->shouldNotReceive('notifyException');
+        $client->shouldReceive('leaveBreadcrumb')->once();
 
         $logger->log('debug', 'hi', ['foo' => 'bar']);
     }
@@ -36,6 +38,7 @@ class BugsnagLoggerTest extends TestCase
         $logger = new BugsnagLogger($client = Mockery::mock(Client::class));
 
         $client->shouldReceive('notifyError')->once();
+        $client->shouldNotReceive('leaveBreadcrumb');
 
         $logger->alert('hi!', ['foo' => 'baz']);
     }


### PR DESCRIPTION
Essentially, all we're doing here is leaving a breadcrumb for debug or info log messages, and allowing the main notify function to add breadcrumbs after sending for the other levels so that a the breadcrumb for itself doesn't show up on an error report.

---

Depends on https://github.com/bugsnag/bugsnag-php/pull/323.
