### PR TITLE
Deal with exceptions going through the logger better

### DIFF
--- a/src/BugsnagLogger.php
+++ b/src/BugsnagLogger.php
@@ -44,11 +44,17 @@ class BugsnagLogger extends AbstractLogger
             unset($context['title']);
         }
 
-        $msg = $this->formatMessage($message);
-        $title = $this->limit(isset($title) ? $title : (string) $msg);
-
         if ($level === 'debug' || $level === 'info') {
-            $this->client->leaveBreadcrumb($title, 'log', array_filter(array_merge(['message' => $message, 'severity' => $level], $context)));
+            if ($message instanceof Exception || $message instanceof Throwable) {
+                $title = get_class($message);
+                $data = ['name' => $title, 'message' => $message->getMessage()];
+            } else {
+                $data = ['message' => $message];
+            }
+
+            $metaData = array_merge(array_merge($data, ['severity' => $level]), $context);
+
+            $this->client->leaveBreadcrumb($title, 'log', array_filter($metaData));
 
             return;
         }
@@ -61,6 +67,8 @@ class BugsnagLogger extends AbstractLogger
         if ($message instanceof Exception || $message instanceof Throwable) {
             $this->client->notifyException($message, $callback);
         } else {
+            $msg = $this->formatMessage($message);
+            $title = $this->limit(isset($title) ? $title : (string) $msg);
             $this->client->notifyError($title, $msg, $callback);
         }
     }

--- a/src/BugsnagLogger.php
+++ b/src/BugsnagLogger.php
@@ -44,6 +44,9 @@ class BugsnagLogger extends AbstractLogger
             unset($context['title']);
         }
 
+        $msg = $this->formatMessage($message);
+        $title = $this->limit(isset($title) ? $title : (string) $msg);
+
         if ($level === 'debug' || $level === 'info') {
             if ($message instanceof Exception || $message instanceof Throwable) {
                 $title = get_class($message);
@@ -67,8 +70,6 @@ class BugsnagLogger extends AbstractLogger
         if ($message instanceof Exception || $message instanceof Throwable) {
             $this->client->notifyException($message, $callback);
         } else {
-            $msg = $this->formatMessage($message);
-            $title = $this->limit(isset($title) ? $title : (string) $msg);
             $this->client->notifyError($title, $msg, $callback);
         }
     }


### PR DESCRIPTION
Note that this only affects the case when their level is info or debug.

Before:

![image](https://cloud.githubusercontent.com/assets/2829600/17463743/cb9336ca-5cc4-11e6-9d92-552a6da9fab3.png)

After:

![image](https://cloud.githubusercontent.com/assets/2829600/17463809/adfbce86-5cc6-11e6-8171-337425147e28.png)

For other cases, they go through the notify method, so get treated as actual reports:

![image](https://cloud.githubusercontent.com/assets/2829600/17463811/c92aa894-5cc6-11e6-9a0e-088eadd128bb.png)
