### PR TITLE
Adding severity attributes to PSR logger

### DIFF
--- a/src/BugsnagLogger.php
+++ b/src/BugsnagLogger.php
@@ -62,11 +62,6 @@ class BugsnagLogger extends AbstractLogger
             return;
         }
 
-        $callback = function (Report $report) use ($level, $context) {
-            $report->setMetaData($context);
-            $report->setSeverity($this->getSeverity($level));
-        };
-
         $severityReason = [
             'type' => 'log',
             'attributes' => [
@@ -79,7 +74,11 @@ class BugsnagLogger extends AbstractLogger
         } else {
             $report = Report::fromNamedError($this->client->getConfig(), $title, $msg, false, $severityReason);
         }
-        $this->client->notify($report, $callback);
+
+        $report->setMetaData($context);
+        $report->setSeverity($this->getSeverity($level));
+
+        $this->client->notify($report);
     }
 
     /**

--- a/src/BugsnagLogger.php
+++ b/src/BugsnagLogger.php
@@ -9,6 +9,7 @@ use Throwable;
 
 class BugsnagLogger extends AbstractLogger
 {
+
     /**
      * The bugsnag client instance.
      *
@@ -67,11 +68,16 @@ class BugsnagLogger extends AbstractLogger
             $report->setSeverity($this->getSeverity($level));
         };
 
+        $severityAttributes = [
+            'level' => $level
+        ];
+
         if ($message instanceof Exception || $message instanceof Throwable) {
-            $this->client->notifyException($message, $callback);
+            $report = Report::fromPHPThrowable($this->client->getConfig(), $message, Report::LOG_LEVEL, $severityAttributes);
         } else {
-            $this->client->notifyError($title, $msg, $callback);
+            $report = Report::fromNamedError($this->client->getConfig(), $title, $msg, Report::LOG_LEVEL, $severityAttributes);
         }
+        $this->client->notify($report, $callback);
     }
 
     /**

--- a/src/BugsnagLogger.php
+++ b/src/BugsnagLogger.php
@@ -67,14 +67,17 @@ class BugsnagLogger extends AbstractLogger
             $report->setSeverity($this->getSeverity($level));
         };
 
-        $severityAttributes = [
-            'level' => $level
+        $severityReason = [
+            'type' => 'log',
+            'attributes' => [
+                'level' => $level
+            ]
         ];
 
         if ($message instanceof Exception || $message instanceof Throwable) {
-            $report = Report::fromPHPThrowable($this->client->getConfig(), $message, Report::LOG_LEVEL, $severityAttributes);
+            $report = Report::fromPHPThrowable($this->client->getConfig(), $message, false, $severityReason);
         } else {
-            $report = Report::fromNamedError($this->client->getConfig(), $title, $msg, Report::LOG_LEVEL, $severityAttributes);
+            $report = Report::fromNamedError($this->client->getConfig(), $title, $msg, false, $severityReason);
         }
         $this->client->notify($report, $callback);
     }

--- a/src/BugsnagLogger.php
+++ b/src/BugsnagLogger.php
@@ -9,7 +9,6 @@ use Throwable;
 
 class BugsnagLogger extends AbstractLogger
 {
-
     /**
      * The bugsnag client instance.
      *

--- a/tests/BugsnagLoggerTest.php
+++ b/tests/BugsnagLoggerTest.php
@@ -8,16 +8,16 @@ use Exception;
 use GrahamCampbell\TestBenchCore\MockeryTrait;
 use Mockery;
 use PHPUnit_Framework_TestCase as TestCase;
-/**
- * @runTestsInSeparateProcesses
- * @preserveGlobalState disabled
- */
 
 class ReportStub
 {
     const LOG_LEVEL = 'log_level';
 }
 
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
 class BugsnagLoggerTest extends TestCase
 {
     use MockeryTrait;

--- a/tests/BugsnagLoggerTest.php
+++ b/tests/BugsnagLoggerTest.php
@@ -31,10 +31,12 @@ class BugsnagLoggerTest extends TestCase
             ->with('config', $exception, false, ['type' => 'log', 'attributes' => ['level' => 'error']])
             ->once()
             ->andReturn($report);
+        $report->shouldReceive('setMetaData')->once()->with(Mockery::any());
+        $report->shouldReceive('setSeverity')->once()->with('error');
         
         $client = Mockery::mock(Client::class);
         $client->shouldReceive('getConfig')->once()->andReturn('config');
-        $client->shouldReceive('notify')->once()->with($report, Mockery::any());
+        $client->shouldReceive('notify')->once()->with($report);
         $client->shouldNotReceive('leaveBreadcrumb');
 
         $logger = new BugsnagLogger($client);
@@ -45,7 +47,7 @@ class BugsnagLoggerTest extends TestCase
     {
         $logger = new BugsnagLogger($client = Mockery::mock(Client::class));
 
-        $client->shouldNotReceive('notifyException');
+        $client->shouldNotReceive('notify');
         $client->shouldReceive('leaveBreadcrumb')->once();
 
         $logger->log('debug', 'hi', ['foo' => 'bar']);
@@ -60,10 +62,12 @@ class BugsnagLoggerTest extends TestCase
             ->with('config', Mockery::any(), Mockery::any(), false, ['type' => 'log', 'attributes' => ['level' => 'alert']])
             ->once()
             ->andReturn($report);
+        $report->shouldReceive('setMetaData')->once()->with(Mockery::any());
+        $report->shouldReceive('setSeverity')->once()->with('error');
 
         $client = Mockery::mock(Client::class);
         $client->shouldReceive('getConfig')->once()->andReturn('config');
-        $client->shouldReceive('notify')->once()->with($report, Mockery::any());
+        $client->shouldReceive('notify')->once()->with($report);
         $client->shouldNotReceive('leaveBreadcrumb');
 
         $logger = new BugsnagLogger($client);

--- a/tests/BugsnagLoggerTest.php
+++ b/tests/BugsnagLoggerTest.php
@@ -28,7 +28,7 @@ class BugsnagLoggerTest extends TestCase
 
         $report = Mockery::namedMock('Bugsnag\Report', ReportStub::class);
         $report->shouldReceive('fromPHPThrowable')
-            ->with('config', $exception, 'log_level', ['level' => 'error'])
+            ->with('config', $exception, false, ['type' => 'log', 'attributes' => ['level' => 'error']])
             ->once()
             ->andReturn($report);
         
@@ -57,7 +57,7 @@ class BugsnagLoggerTest extends TestCase
         
         $report = Mockery::namedMock('Bugsnag\Report', ReportStub::class);
         $report->shouldReceive('fromNamedError')
-            ->with('config', Mockery::any(), Mockery::any(), 'log_level', ['level' => 'alert'])
+            ->with('config', Mockery::any(), Mockery::any(), false, ['type' => 'log', 'attributes' => ['level' => 'alert']])
             ->once()
             ->andReturn($report);
 


### PR DESCRIPTION
- Ensures correct severity attributes notified to bugsnag-client when logging
- Includes updating Laravel due to unhandled errors requiring this library for notification