### PR TITLE
Allow overriding message exception using context

### DIFF
--- a/src/BugsnagLogger.php
+++ b/src/BugsnagLogger.php
@@ -60,7 +60,7 @@ class BugsnagLogger extends AbstractLogger
                 $data = ['message' => $message];
             }
 
-            $metaData = array_merge(array_merge($data, ['severity' => $level]), $context);
+            $metaData = array_merge($data, $context);
 
             $this->client->leaveBreadcrumb($title, 'log', array_filter($metaData));
 

--- a/src/BugsnagLogger.php
+++ b/src/BugsnagLogger.php
@@ -39,18 +39,23 @@ class BugsnagLogger extends AbstractLogger
      */
     public function log($level, $message, array $context = [])
     {
+        $title = 'Log ' . $level;
         if (isset($context['title'])) {
             $title = $context['title'];
             unset($context['title']);
         }
 
-        $msg = $this->formatMessage($message);
-        $title = $this->limit(isset($title) ? $title : (string) $msg);
+        $exception = null;
+        if (isset($context['exception'])) {
+            $exception = $context['exception'];
+        } else if ($message instanceof Exception || $message instanceof Throwable) {
+            $exception = $message;
+        }
 
         if ($level === 'debug' || $level === 'info') {
-            if ($message instanceof Exception || $message instanceof Throwable) {
-                $title = get_class($message);
-                $data = ['name' => $title, 'message' => $message->getMessage()];
+            if ($exception !== null) {
+                $title = get_class($exception);
+                $data = ['name' => $title, 'message' => $exception->getMessage()];
             } else {
                 $data = ['message' => $message];
             }
@@ -67,10 +72,10 @@ class BugsnagLogger extends AbstractLogger
             $report->setSeverity($this->getSeverity($level));
         };
 
-        if ($message instanceof Exception || $message instanceof Throwable) {
-            $this->client->notifyException($message, $callback);
+        if ($exception !== null) {
+            $this->client->notifyException($exception, $callback);
         } else {
-            $this->client->notifyError($title, $msg, $callback);
+            $this->client->notifyError($title, $this->formatMessage($message), $callback);
         }
     }
 

--- a/tests/BugsnagLoggerTest.php
+++ b/tests/BugsnagLoggerTest.php
@@ -36,6 +36,18 @@ class BugsnagLoggerTest extends TestCase
         $logger->log('error', 'terrible things!', ['exception' => $exception]);
     }
 
+    public function testInfo()
+    {
+        $logger = new BugsnagLogger($client = Mockery::mock(Client::class));
+
+        $client->shouldNotReceive('notifyException');
+        $client->shouldReceive('leaveBreadcrumb')
+            ->once()
+            ->withArgs(['Log info', 'log', ['foo' => 'bar', 'message' => 'hi']]);
+
+        $logger->log('info', 'hi', ['foo' => 'bar']);
+    }
+
     public function testDebug()
     {
         $logger = new BugsnagLogger($client = Mockery::mock(Client::class));
@@ -43,7 +55,7 @@ class BugsnagLoggerTest extends TestCase
         $client->shouldNotReceive('notifyException');
         $client->shouldReceive('leaveBreadcrumb')
             ->once()
-            ->withArgs(['Log debug', 'log', ['foo' => 'bar', 'severity' => 'debug', 'message' => 'hi']]);
+            ->withArgs(['Log debug', 'log', ['foo' => 'bar', 'message' => 'hi']]);
 
         $logger->log('debug', 'hi', ['foo' => 'bar']);
     }


### PR DESCRIPTION
In the case that the log context contains an exception, use that instead of the message to report to Bugsnag.

Related to bugsnag/bugsnag-laravel#246