### PR TITLE
Only take the Exception from the Context if it's of the correct type

### DIFF
--- a/src/BugsnagLogger.php
+++ b/src/BugsnagLogger.php
@@ -46,7 +46,7 @@ class BugsnagLogger extends AbstractLogger
         }
 
         $exception = null;
-        if (isset($context['exception'])) {
+        if (isset($context['exception']) && ($context['exception'] instanceof Exception || $context['exception'] instanceof Throwable)) {
             $exception = $context['exception'];
         } else if ($message instanceof Exception || $message instanceof Throwable) {
             $exception = $message;


### PR DESCRIPTION
This fixes an issue where the key `exception` is passed to the Context as something other than the Exception instance (i.e. the message).