### PR TITLE
Adds log-level configuration to PSR logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ $multiLogger = new Bugsnag\PsrLogger\MultiLogger([$logger, $mySecondLogger]);
 $multiLogger.error('An error occurred');
 ```
 
+The default level at which logs will be sent to Bugsnag is `Psr\Log\LogLevel::NOTICE`.  This can be overridden using the `setNotifyLevel` function:
+
+```php
+$logger = new Bugsnag\PsrLogger\BugsnagLogger($bugsnag);
+
+# Will not send a notification to bugsnag by default
+$logger->info('Some interesting information');
+
+$logger->setNotifyLevel(Psr\Log\LogLevel::INFO);
+
+# Will send a notification to bugsnag
+$logger->info('Some more interesting information');
+```
+
 
 For more information on integrating the loggers into specific frameworks see the individual setup information found in the [bugsnag-php documentation](https://docs.bugsnag.com/platforms/php/).
 

--- a/examples/plain/composer.json
+++ b/examples/plain/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "bugsnag/bugsnag-psr-logger": "^1.2"
+    }
+}

--- a/examples/plain/index.php
+++ b/examples/plain/index.php
@@ -1,0 +1,13 @@
+<?php
+
+require_once 'vendor/autoload.php';
+
+$bugsnag = Bugsnag\Client::make('YOUR-API-KEY');
+$logger = new Bugsnag\PsrLogger\BugsnagLogger($bugsnag);
+$logger->setNotifyLevel(\Psr\Log\LogLevel::ERROR);
+
+// Add breadcrumbs for low-severity log messages
+$logger->notice('Reticulating splines');
+
+// Log an exception to Bugsnag
+$logger->error(new Exception('Invalid configuration at runtime'));

--- a/src/AbstractLogger.php
+++ b/src/AbstractLogger.php
@@ -2,9 +2,7 @@
 
 namespace Bugsnag\PsrLogger;
 
-use Psr\Log\LoggerInterface;
-
-abstract class AbstractLogger implements LoggerInterface
+abstract class AbstractLogger implements \Psr\Log\LoggerInterface
 {
     /**
      * Log an emergency message to the logs.

--- a/src/BugsnagLogger.php
+++ b/src/BugsnagLogger.php
@@ -39,9 +39,9 @@ class BugsnagLogger extends AbstractLogger
 
     /**
      * Set the notifyLevel of the logger, as defined in Psr\Log\LogLevel.
-     * 
+     *
      * @param string $notifyLevel
-     * 
+     *
      * @return void
      */
     public function setNotifyLevel($notifyLevel)

--- a/src/BugsnagLogger.php
+++ b/src/BugsnagLogger.php
@@ -10,17 +10,6 @@ use Throwable;
 class BugsnagLogger extends AbstractLogger
 {
 
-    const LevelOrder = [
-        'debug',
-        'info',
-        'notice',
-        'warning',
-        'error',
-        'critical',
-        'alert',
-        'emergency'
-    ];
-
     /**
      * The bugsnag client instance.
      *
@@ -130,8 +119,18 @@ class BugsnagLogger extends AbstractLogger
      */
     protected function aboveLevel($level, $base)
     {
-        $baseIndex = array_search($base, $this::LevelOrder);
-        $levelIndex = array_search($level, $this::LevelOrder);
+        $levelOrder = [
+            'debug',
+            'info',
+            'notice',
+            'warning',
+            'error',
+            'critical',
+            'alert',
+            'emergency'
+        ];
+        $baseIndex = array_search($base, $LevelOrder);
+        $levelIndex = array_search($level, $LevelOrder);
         return $levelIndex >= $baseIndex;
     }
 

--- a/src/BugsnagLogger.php
+++ b/src/BugsnagLogger.php
@@ -5,6 +5,7 @@ namespace Bugsnag\PsrLogger;
 use Bugsnag\Client;
 use Bugsnag\Report;
 use Exception;
+use TypeError;
 use Psr\Log\LogLevel;
 use Throwable;
 
@@ -37,8 +38,18 @@ class BugsnagLogger extends AbstractLogger
         $this->client = $client;
     }
 
+    /**
+     * Set the notifyLevel of the logger, as defined in Psr\Log\LogLevel.
+     * 
+     * @param string $notifyLevel
+     * 
+     * @return void
+     */
     public function setNotifyLevel($notifyLevel)
     {
+        if (!in_array($notifyLevel, $this->getLogLevelOrder())) {
+            throw new TypeError("notifyLevel must be a valid Psr\Log\LogLevel value");
+        }
         $this->notifyLevel = $notifyLevel;
     }
 
@@ -107,7 +118,19 @@ class BugsnagLogger extends AbstractLogger
      */
     protected function aboveLevel($level, $base)
     {
-        $levelOrder = [
+        $levelOrder = $this->getLogLevelOrder();
+        $baseIndex = array_search($base, $levelOrder);
+        $levelIndex = array_search($level, $levelOrder);
+
+        return $levelIndex >= $baseIndex;
+    }
+
+    /**
+     * Returns a list of log levels in order.
+     */
+    protected function getLogLevelOrder()
+    {
+        return [
             LogLevel::DEBUG,
             LogLevel::INFO,
             LogLevel::NOTICE,
@@ -116,10 +139,6 @@ class BugsnagLogger extends AbstractLogger
             LogLevel::ALERT,
             LogLevel::EMERGENCY,
         ];
-        $baseIndex = array_search($base, $levelOrder);
-        $levelIndex = array_search($level, $levelOrder);
-
-        return $levelIndex >= $baseIndex;
     }
 
     /**

--- a/src/BugsnagLogger.php
+++ b/src/BugsnagLogger.php
@@ -19,6 +19,7 @@ class BugsnagLogger extends AbstractLogger
 
     /**
      * The minimum level required to notify bugsnag.
+     * Logs underneath this level will be converted into breadcrumbs.
      *
      * @var string
      */

--- a/src/BugsnagLogger.php
+++ b/src/BugsnagLogger.php
@@ -5,7 +5,6 @@ namespace Bugsnag\PsrLogger;
 use Bugsnag\Client;
 use Bugsnag\Report;
 use Exception;
-use TypeError;
 use Psr\Log\LogLevel;
 use Throwable;
 

--- a/src/BugsnagLogger.php
+++ b/src/BugsnagLogger.php
@@ -25,20 +25,6 @@ class BugsnagLogger extends AbstractLogger
     protected $notifyLevel;
 
     /**
-     * The minimum level required to set the notification level to 'warning'.
-     * 
-     * @var string
-     */
-    protected $warningLevel;
-
-    /**
-     * The minimum level required to set the notification level to 'error'.
-     * 
-     * @var string
-     */
-    protected $errorLevel;
-
-    /**
      * Create a new bugsnag logger instance.
      *
      * @param \Bugsnag\Client $client
@@ -48,10 +34,8 @@ class BugsnagLogger extends AbstractLogger
     public function __construct(Client $client)
     {
         $this->client = $client;
-        $logLevels = $this->client->getConfig()->getLogLevels();
-        $this->notifyLevel = !is_null($logLevels["notifyLevel"]) ? $logLevels["notifyLevel"] : 'notice';
-        $this->warningLevel = !is_null($logLevels["warningLevel"]) ? $logLevels["warningLevel"] : 'warning';
-        $this->errorLevel = !is_null($logLevels["errorLevel"]) ? $logLevels["errorLevel"] : 'error';
+        $logNotifyLevel = $this->client->getConfig()->getLogLevel();
+        $this->notifyLevel = !is_null($logNotifyLevel) ? $logNotifyLevel : 'notice';
     }
 
     /**
@@ -143,9 +127,9 @@ class BugsnagLogger extends AbstractLogger
      */
     protected function getSeverity($level)
     {
-        if (!$this->aboveLevel($level, $this->warningLevel)) {
+        if (!$this->aboveLevel($level, 'notice')) {
             return 'info';
-        } elseif (!$this->aboveLevel($level, $this->errorLevel)) {
+        } elseif (!$this->aboveLevel($level, 'warning')) {
             return 'warning';
         } else {
             return 'error';

--- a/src/BugsnagLogger.php
+++ b/src/BugsnagLogger.php
@@ -53,9 +53,6 @@ class BugsnagLogger extends AbstractLogger
      * Create a new bugsnag logger instance.
      *
      * @param \Bugsnag\Client $client
-     * @param string $threshold (optional)
-     * @param string $warningLevel (optional)
-     * @param string $errorLevel (optional)
      *
      * @return void
      */
@@ -63,9 +60,12 @@ class BugsnagLogger extends AbstractLogger
     {
         $this->client = $client;
         $config = $this->client->getConfig();
-        $this->threshold = !is_null($config->logLevel) ? $config->logLevel : 'notice';
-        $this->warningLevel = !is_null($config->logWarningLevel) ? $config->logWarningLevel : 'warning';
-        $this->errorLevel = !is_null($config->logErrorLevel) ? $config->logErrorLevel : 'error';
+        $logLevel = $config->getLogLevel();
+        $warningLevel = $config->getLogWarningLevel();
+        $errorLevel = $config->getLogErrorLevel();
+        $this->threshold = !is_null($logLevel) ? $logLevel : 'notice';
+        $this->warningLevel = !is_null($warningLevel) ? $warningLevel : 'warning';
+        $this->errorLevel = !is_null($errorLevel) ? $errorLevel : 'error';
     }
 
     /**

--- a/src/BugsnagLogger.php
+++ b/src/BugsnagLogger.php
@@ -4,7 +4,6 @@ namespace Bugsnag\PsrLogger;
 
 use Bugsnag\Client;
 use Bugsnag\Report;
-use Psr\Log\LogLevel;
 use Exception;
 use Throwable;
 
@@ -64,7 +63,7 @@ class BugsnagLogger extends AbstractLogger
     {
         $this->client = $client;
         $config = $this->client->getConfig();
-        $this->threshold = !is_null($config->logThreshold) ? $config->logThreshold : 'notice';
+        $this->threshold = !is_null($config->logLevel) ? $config->logLevel : 'notice';
         $this->warningLevel = !is_null($config->logWarningLevel) ? $config->logWarningLevel : 'warning';
         $this->errorLevel = !is_null($config->logErrorLevel) ? $config->logErrorLevel : 'error';
     }

--- a/src/BugsnagLogger.php
+++ b/src/BugsnagLogger.php
@@ -33,7 +33,7 @@ class BugsnagLogger extends AbstractLogger
      * 
      * @var string
      */
-    protected $threshold;
+    protected $notifyLevel;
 
     /**
      * The minimum level required to set the notification level to 'warning'.
@@ -59,13 +59,10 @@ class BugsnagLogger extends AbstractLogger
     public function __construct(Client $client)
     {
         $this->client = $client;
-        $config = $this->client->getConfig();
-        $logLevel = $config->getLogLevel();
-        $warningLevel = $config->getLogWarningLevel();
-        $errorLevel = $config->getLogErrorLevel();
-        $this->threshold = !is_null($logLevel) ? $logLevel : 'notice';
-        $this->warningLevel = !is_null($warningLevel) ? $warningLevel : 'warning';
-        $this->errorLevel = !is_null($errorLevel) ? $errorLevel : 'error';
+        $logLevels = $this->client->getConfig()->getLogLevels();
+        $this->notifyLevel = !is_null($logLevels["notifyLevel"]) ? $logLevels["notifyLevel"] : 'notice';
+        $this->warningLevel = !is_null($logLevels["warningLevel"]) ? $logLevels["warningLevel"] : 'warning';
+        $this->errorLevel = !is_null($logLevels["errorLevel"]) ? $logLevels["errorLevel"] : 'error';
     }
 
     /**
@@ -93,7 +90,7 @@ class BugsnagLogger extends AbstractLogger
         }
 
         # Below theshold, leave a breadcrumb but don't send a notification
-        if (!$this->aboveLevel($level, $this->threshold)) {
+        if (!$this->aboveLevel($level, $this->notifyLevel)) {
             if ($exception !== null) {
                 $title = get_class($exception);
                 $data = ['name' => $title, 'message' => $exception->getMessage()];

--- a/src/BugsnagLogger.php
+++ b/src/BugsnagLogger.php
@@ -48,9 +48,10 @@ class BugsnagLogger extends AbstractLogger
     public function setNotifyLevel($notifyLevel)
     {
         if (!in_array($notifyLevel, $this->getLogLevelOrder())) {
-            throw new TypeError("notifyLevel must be a valid Psr\Log\LogLevel value");
+            syslog(LOG_WARNING, 'Bugsnag Warning: Invalid notify level supplied to Bugsnag Logger');
+        } else {
+            $this->notifyLevel = $notifyLevel;
         }
-        $this->notifyLevel = $notifyLevel;
     }
 
     /**

--- a/src/BugsnagLogger.php
+++ b/src/BugsnagLogger.php
@@ -129,8 +129,8 @@ class BugsnagLogger extends AbstractLogger
             'alert',
             'emergency'
         ];
-        $baseIndex = array_search($base, $LevelOrder);
-        $levelIndex = array_search($level, $LevelOrder);
+        $baseIndex = array_search($base, $levelOrder);
+        $levelIndex = array_search($level, $levelOrder);
         return $levelIndex >= $baseIndex;
     }
 

--- a/tests/BugsnagLoggerTest.php
+++ b/tests/BugsnagLoggerTest.php
@@ -6,6 +6,7 @@ use Bugsnag\Client;
 use Bugsnag\Configuration;
 use Bugsnag\PsrLogger\BugsnagLogger;
 use Exception;
+use TypeError;
 use GrahamCampbell\TestBenchCore\MockeryTrait;
 use Mockery;
 use PHPUnit_Framework_TestCase as TestCase;
@@ -220,6 +221,19 @@ class BugsnagLoggerTest extends TestCase
             ->once()
             ->withArgs(['Log info', 'log', ['foo' => 'baz', 'message' => 'hi']]);
         $logger->info('hi', ['foo' => 'baz']);
+    }
+
+    /**
+     * @expectedException TypeError
+     */
+    public function testInvalidLogLevelThrows()
+    {
+        $config = Mockery::mock(Configuration::class)->makePartial();
+        $client = Mockery::mock(Client::class)->makePartial();
+        $client->shouldReceive('getConfig')->andReturn($config);
+
+        $logger = new BugsnagLogger($client);
+        $logger->setNotifyLevel('not a real log level');
     }
 
     /**

--- a/tests/BugsnagLoggerTest.php
+++ b/tests/BugsnagLoggerTest.php
@@ -28,9 +28,9 @@ class BugsnagLoggerTest extends TestCase
         $exception = new Exception();
 
         $config = Mockery::mock(Configuration::class);
-        $config->logLevel = null;
-        $config->logWarningLevel = null;
-        $config->logErrorLevel = null;
+        $config->shouldReceive('getLogLevel')->andReturn(null);
+        $config->shouldReceive('getLogWarningLevel')->andReturn(null);
+        $config->shouldReceive('getLogErrorLevel')->andReturn(null);
 
         $report = Mockery::namedMock('Bugsnag\Report', ReportStub::class);
         $report->shouldReceive('fromPHPThrowable')
@@ -55,9 +55,9 @@ class BugsnagLoggerTest extends TestCase
         $exception = new Exception();
         
         $config = Mockery::mock(Configuration::class);
-        $config->logLevel = null;
-        $config->logWarningLevel = null;
-        $config->logErrorLevel = null;
+        $config->shouldReceive('getLogLevel')->andReturn(null);
+        $config->shouldReceive('getLogWarningLevel')->andReturn(null);
+        $config->shouldReceive('getLogErrorLevel')->andReturn(null);
 
         $report = Mockery::namedMock('Bugsnag\Report', ReportStub::class);
         $report->shouldReceive('fromPHPThrowable')
@@ -82,9 +82,9 @@ class BugsnagLoggerTest extends TestCase
         $exception = new Exception();
 
         $config = Mockery::mock(Configuration::class);
-        $config->logLevel = null;
-        $config->logWarningLevel = null;
-        $config->logErrorLevel = null;
+        $config->shouldReceive('getLogLevel')->andReturn(null);
+        $config->shouldReceive('getLogWarningLevel')->andReturn(null);
+        $config->shouldReceive('getLogErrorLevel')->andReturn(null);
 
         $report = Mockery::namedMock('Bugsnag\Report', ReportStub::class);
         $report->shouldReceive('fromNamedError')
@@ -107,9 +107,9 @@ class BugsnagLoggerTest extends TestCase
     public function testInfo()
     {
         $config = Mockery::mock(Configuration::class);
-        $config->logLevel = null;
-        $config->logWarningLevel = null;
-        $config->logErrorLevel = null;
+        $config->shouldReceive('getLogLevel')->andReturn(null);
+        $config->shouldReceive('getLogWarningLevel')->andReturn(null);
+        $config->shouldReceive('getLogErrorLevel')->andReturn(null);
 
         $client = Mockery::mock(Client::class);
         $client->shouldReceive('getConfig')->andReturn($config);
@@ -125,9 +125,9 @@ class BugsnagLoggerTest extends TestCase
     public function testDebug()
     {
         $config = Mockery::mock(Configuration::class);
-        $config->logLevel = null;
-        $config->logWarningLevel = null;
-        $config->logErrorLevel = null;
+        $config->shouldReceive('getLogLevel')->andReturn(null);
+        $config->shouldReceive('getLogWarningLevel')->andReturn(null);
+        $config->shouldReceive('getLogErrorLevel')->andReturn(null);
 
         $client = Mockery::mock(Client::class);
         $client->shouldReceive('getConfig')->andReturn($config);
@@ -145,9 +145,9 @@ class BugsnagLoggerTest extends TestCase
         $exception = new Exception();
 
         $config = Mockery::mock(Configuration::class);
-        $config->logLevel = null;
-        $config->logWarningLevel = null;
-        $config->logErrorLevel = null;
+        $config->shouldReceive('getLogLevel')->andReturn(null);
+        $config->shouldReceive('getLogWarningLevel')->andReturn(null);
+        $config->shouldReceive('getLogErrorLevel')->andReturn(null);
         
         $report = Mockery::namedMock('Bugsnag\Report', ReportStub::class);
         $report->shouldReceive('fromNamedError')
@@ -170,9 +170,9 @@ class BugsnagLoggerTest extends TestCase
     public function testLogLevel()
     {
         $config = Mockery::mock(Configuration::class);
-        $config->logLevel = 'error';
-        $config->logWarningLevel = null;
-        $config->logErrorLevel = null;
+        $config->shouldReceive('getLogLevel')->andReturn('error');
+        $config->shouldReceive('getLogWarningLevel')->andReturn(null);
+        $config->shouldReceive('getLogErrorLevel')->andReturn(null);
 
         $report = Mockery::namedMock('Bugsnag\Report', ReportStub::class);
         $report->shouldReceive('fromNamedError')
@@ -199,9 +199,9 @@ class BugsnagLoggerTest extends TestCase
     public function testWarningLevel()
     {
         $config = Mockery::mock(Configuration::class);
-        $config->logLevel = null;
-        $config->logWarningLevel = 'notice';
-        $config->logErrorLevel = null;
+        $config->shouldReceive('getLogLevel')->andReturn(null);
+        $config->shouldReceive('getLogWarningLevel')->andReturn('notice');
+        $config->shouldReceive('getLogErrorLevel')->andReturn(null);
 
         $report = Mockery::namedMock('Bugsnag\Report', ReportStub::class);
         $report->shouldReceive('fromNamedError')
@@ -224,9 +224,9 @@ class BugsnagLoggerTest extends TestCase
     public function testErrorLevel()
     {
         $config = Mockery::mock(Configuration::class);
-        $config->logLevel = null;
-        $config->logWarningLevel = null;
-        $config->logErrorLevel = 'warning';
+        $config->shouldReceive('getLogLevel')->andReturn(null);
+        $config->shouldReceive('getLogWarningLevel')->andReturn(null);
+        $config->shouldReceive('getLogErrorLevel')->andReturn('warning');
 
         $report = Mockery::namedMock('Bugsnag\Report', ReportStub::class);
         $report->shouldReceive('fromNamedError')

--- a/tests/BugsnagLoggerTest.php
+++ b/tests/BugsnagLoggerTest.php
@@ -28,11 +28,7 @@ class BugsnagLoggerTest extends TestCase
         $exception = new Exception();
 
         $config = Mockery::mock(Configuration::class);
-        $config->shouldReceive('getLogLevels')->andReturn([
-            "notifyLevel" => null,
-            "warningLevel" => null,
-            "errorLevel" => null
-        ]);
+        $config->shouldReceive('getLogLevel')->andReturn(null);
 
         $report = Mockery::namedMock('Bugsnag\Report', ReportStub::class);
         $report->shouldReceive('fromPHPThrowable')
@@ -57,12 +53,7 @@ class BugsnagLoggerTest extends TestCase
         $exception = new Exception();
         
         $config = Mockery::mock(Configuration::class);
-        $config->shouldReceive('getLogLevels')->andReturn([
-            "notifyLevel" => null,
-            "warningLevel" => null,
-            "errorLevel" => null
-        ]);
-
+        $config->shouldReceive('getLogLevel')->andReturn(null);
 
         $report = Mockery::namedMock('Bugsnag\Report', ReportStub::class);
         $report->shouldReceive('fromPHPThrowable')
@@ -87,12 +78,7 @@ class BugsnagLoggerTest extends TestCase
         $exception = new Exception();
 
         $config = Mockery::mock(Configuration::class);
-        $config->shouldReceive('getLogLevels')->andReturn([
-            "notifyLevel" => null,
-            "warningLevel" => null,
-            "errorLevel" => null
-        ]);
-
+        $config->shouldReceive('getLogLevel')->andReturn(null);
 
         $report = Mockery::namedMock('Bugsnag\Report', ReportStub::class);
         $report->shouldReceive('fromNamedError')
@@ -115,12 +101,7 @@ class BugsnagLoggerTest extends TestCase
     public function testInfo()
     {
         $config = Mockery::mock(Configuration::class);
-        $config->shouldReceive('getLogLevels')->andReturn([
-            "notifyLevel" => null,
-            "warningLevel" => null,
-            "errorLevel" => null
-        ]);
-
+        $config->shouldReceive('getLogLevel')->andReturn(null);
 
         $client = Mockery::mock(Client::class);
         $client->shouldReceive('getConfig')->andReturn($config);
@@ -136,12 +117,7 @@ class BugsnagLoggerTest extends TestCase
     public function testDebug()
     {
         $config = Mockery::mock(Configuration::class);
-        $config->shouldReceive('getLogLevels')->andReturn([
-            "notifyLevel" => null,
-            "warningLevel" => null,
-            "errorLevel" => null
-        ]);
-
+        $config->shouldReceive('getLogLevel')->andReturn(null);
 
         $client = Mockery::mock(Client::class);
         $client->shouldReceive('getConfig')->andReturn($config);
@@ -159,12 +135,7 @@ class BugsnagLoggerTest extends TestCase
         $exception = new Exception();
 
         $config = Mockery::mock(Configuration::class);
-        $config->shouldReceive('getLogLevels')->andReturn([
-            "notifyLevel" => null,
-            "warningLevel" => null,
-            "errorLevel" => null
-        ]);
-
+        $config->shouldReceive('getLogLevel')->andReturn(null);
         
         $report = Mockery::namedMock('Bugsnag\Report', ReportStub::class);
         $report->shouldReceive('fromNamedError')
@@ -187,11 +158,7 @@ class BugsnagLoggerTest extends TestCase
     public function testLogLevel()
     {
         $config = Mockery::mock(Configuration::class);
-        $config->shouldReceive('getLogLevels')->andReturn([
-            "notifyLevel" => "error",
-            "warningLevel" => null,
-            "errorLevel" => null
-        ]);
+        $config->shouldReceive('getLogLevel')->andReturn('error');
 
         $report = Mockery::namedMock('Bugsnag\Report', ReportStub::class);
         $report->shouldReceive('fromNamedError')
@@ -213,59 +180,5 @@ class BugsnagLoggerTest extends TestCase
         $logger->warning('hi', ['foo' => 'baz']);
 
         $logger->error('hi', ['bar' => 'fuu']);
-    }
-
-    public function testWarningLevel()
-    {
-        $config = Mockery::mock(Configuration::class);
-        $config->shouldReceive('getLogLevels')->andReturn([
-            "notifyLevel" => null,
-            "warningLevel" => "notice",
-            "errorLevel" => null
-        ]);
-
-        $report = Mockery::namedMock('Bugsnag\Report', ReportStub::class);
-        $report->shouldReceive('fromNamedError')
-            ->with($config, Mockery::any(), Mockery::any())
-            ->once()
-            ->andReturn($report);
-        $report->shouldReceive('setMetaData')->once()->with(Mockery::any());
-        $report->shouldReceive('setSeverity')->once()->with('warning');
-        $report->shouldReceive('setSeverityReason')->once()->with(['type' => 'log', 'attributes' => ['level' => 'notice']]);
-
-        $client = Mockery::mock(Client::class);
-        $client->shouldReceive('getConfig')->andReturn($config);
-        $client->shouldReceive('notify')->once()->with($report);
-        $client->shouldNotReceive('leaveBreadcrumb');
-
-        $logger = new BugsnagLogger($client);
-        $logger->notice('notice', ['type' => 'notice']);
-    }
-
-    public function testErrorLevel()
-    {
-        $config = Mockery::mock(Configuration::class);
-        $config->shouldReceive('getLogLevels')->andReturn([
-            "notifyLevel" => null,
-            "warningLevel" => null,
-            "errorLevel" => "warning"
-        ]);
-
-        $report = Mockery::namedMock('Bugsnag\Report', ReportStub::class);
-        $report->shouldReceive('fromNamedError')
-            ->with($config, Mockery::any(), Mockery::any())
-            ->once()
-            ->andReturn($report);
-        $report->shouldReceive('setMetaData')->once()->with(Mockery::any());
-        $report->shouldReceive('setSeverity')->once()->with('error');
-        $report->shouldReceive('setSeverityReason')->once()->with(['type' => 'log', 'attributes' => ['level' => 'warning']]);
-
-        $client = Mockery::mock(Client::class);
-        $client->shouldReceive('getConfig')->andReturn($config);
-        $client->shouldReceive('notify')->once()->with($report);
-        $client->shouldNotReceive('leaveBreadcrumb');
-
-        $logger = new BugsnagLogger($client);
-        $logger->warning('warning', ['type' => 'warning']);
     }
 }

--- a/tests/BugsnagLoggerTest.php
+++ b/tests/BugsnagLoggerTest.php
@@ -4,9 +4,7 @@ namespace Bugsnag\PsrLogger;
 
 use Bugsnag\Client;
 use Bugsnag\Configuration;
-use Bugsnag\PsrLogger\BugsnagLogger;
 use Exception;
-use TypeError;
 use GrahamCampbell\TestBenchCore\MockeryTrait;
 use Mockery;
 use PHPUnit_Framework_TestCase as TestCase;
@@ -19,7 +17,8 @@ class ReportStub
 global $sysprio;
 global $sysmes;
 
-function syslog($priority, $message) {
+function syslog($priority, $message)
+{
     global $sysprio;
     global $sysmes;
 

--- a/tests/BugsnagLoggerTest.php
+++ b/tests/BugsnagLoggerTest.php
@@ -28,9 +28,11 @@ class BugsnagLoggerTest extends TestCase
         $exception = new Exception();
 
         $config = Mockery::mock(Configuration::class);
-        $config->shouldReceive('getLogLevel')->andReturn(null);
-        $config->shouldReceive('getLogWarningLevel')->andReturn(null);
-        $config->shouldReceive('getLogErrorLevel')->andReturn(null);
+        $config->shouldReceive('getLogLevels')->andReturn([
+            "notifyLevel" => null,
+            "warningLevel" => null,
+            "errorLevel" => null
+        ]);
 
         $report = Mockery::namedMock('Bugsnag\Report', ReportStub::class);
         $report->shouldReceive('fromPHPThrowable')
@@ -55,9 +57,12 @@ class BugsnagLoggerTest extends TestCase
         $exception = new Exception();
         
         $config = Mockery::mock(Configuration::class);
-        $config->shouldReceive('getLogLevel')->andReturn(null);
-        $config->shouldReceive('getLogWarningLevel')->andReturn(null);
-        $config->shouldReceive('getLogErrorLevel')->andReturn(null);
+        $config->shouldReceive('getLogLevels')->andReturn([
+            "notifyLevel" => null,
+            "warningLevel" => null,
+            "errorLevel" => null
+        ]);
+
 
         $report = Mockery::namedMock('Bugsnag\Report', ReportStub::class);
         $report->shouldReceive('fromPHPThrowable')
@@ -82,9 +87,12 @@ class BugsnagLoggerTest extends TestCase
         $exception = new Exception();
 
         $config = Mockery::mock(Configuration::class);
-        $config->shouldReceive('getLogLevel')->andReturn(null);
-        $config->shouldReceive('getLogWarningLevel')->andReturn(null);
-        $config->shouldReceive('getLogErrorLevel')->andReturn(null);
+        $config->shouldReceive('getLogLevels')->andReturn([
+            "notifyLevel" => null,
+            "warningLevel" => null,
+            "errorLevel" => null
+        ]);
+
 
         $report = Mockery::namedMock('Bugsnag\Report', ReportStub::class);
         $report->shouldReceive('fromNamedError')
@@ -107,9 +115,12 @@ class BugsnagLoggerTest extends TestCase
     public function testInfo()
     {
         $config = Mockery::mock(Configuration::class);
-        $config->shouldReceive('getLogLevel')->andReturn(null);
-        $config->shouldReceive('getLogWarningLevel')->andReturn(null);
-        $config->shouldReceive('getLogErrorLevel')->andReturn(null);
+        $config->shouldReceive('getLogLevels')->andReturn([
+            "notifyLevel" => null,
+            "warningLevel" => null,
+            "errorLevel" => null
+        ]);
+
 
         $client = Mockery::mock(Client::class);
         $client->shouldReceive('getConfig')->andReturn($config);
@@ -125,9 +136,12 @@ class BugsnagLoggerTest extends TestCase
     public function testDebug()
     {
         $config = Mockery::mock(Configuration::class);
-        $config->shouldReceive('getLogLevel')->andReturn(null);
-        $config->shouldReceive('getLogWarningLevel')->andReturn(null);
-        $config->shouldReceive('getLogErrorLevel')->andReturn(null);
+        $config->shouldReceive('getLogLevels')->andReturn([
+            "notifyLevel" => null,
+            "warningLevel" => null,
+            "errorLevel" => null
+        ]);
+
 
         $client = Mockery::mock(Client::class);
         $client->shouldReceive('getConfig')->andReturn($config);
@@ -145,9 +159,12 @@ class BugsnagLoggerTest extends TestCase
         $exception = new Exception();
 
         $config = Mockery::mock(Configuration::class);
-        $config->shouldReceive('getLogLevel')->andReturn(null);
-        $config->shouldReceive('getLogWarningLevel')->andReturn(null);
-        $config->shouldReceive('getLogErrorLevel')->andReturn(null);
+        $config->shouldReceive('getLogLevels')->andReturn([
+            "notifyLevel" => null,
+            "warningLevel" => null,
+            "errorLevel" => null
+        ]);
+
         
         $report = Mockery::namedMock('Bugsnag\Report', ReportStub::class);
         $report->shouldReceive('fromNamedError')
@@ -170,9 +187,11 @@ class BugsnagLoggerTest extends TestCase
     public function testLogLevel()
     {
         $config = Mockery::mock(Configuration::class);
-        $config->shouldReceive('getLogLevel')->andReturn('error');
-        $config->shouldReceive('getLogWarningLevel')->andReturn(null);
-        $config->shouldReceive('getLogErrorLevel')->andReturn(null);
+        $config->shouldReceive('getLogLevels')->andReturn([
+            "notifyLevel" => "error",
+            "warningLevel" => null,
+            "errorLevel" => null
+        ]);
 
         $report = Mockery::namedMock('Bugsnag\Report', ReportStub::class);
         $report->shouldReceive('fromNamedError')
@@ -199,9 +218,11 @@ class BugsnagLoggerTest extends TestCase
     public function testWarningLevel()
     {
         $config = Mockery::mock(Configuration::class);
-        $config->shouldReceive('getLogLevel')->andReturn(null);
-        $config->shouldReceive('getLogWarningLevel')->andReturn('notice');
-        $config->shouldReceive('getLogErrorLevel')->andReturn(null);
+        $config->shouldReceive('getLogLevels')->andReturn([
+            "notifyLevel" => null,
+            "warningLevel" => "notice",
+            "errorLevel" => null
+        ]);
 
         $report = Mockery::namedMock('Bugsnag\Report', ReportStub::class);
         $report->shouldReceive('fromNamedError')
@@ -224,9 +245,11 @@ class BugsnagLoggerTest extends TestCase
     public function testErrorLevel()
     {
         $config = Mockery::mock(Configuration::class);
-        $config->shouldReceive('getLogLevel')->andReturn(null);
-        $config->shouldReceive('getLogWarningLevel')->andReturn(null);
-        $config->shouldReceive('getLogErrorLevel')->andReturn('warning');
+        $config->shouldReceive('getLogLevels')->andReturn([
+            "notifyLevel" => null,
+            "warningLevel" => null,
+            "errorLevel" => "warning"
+        ]);
 
         $report = Mockery::namedMock('Bugsnag\Report', ReportStub::class);
         $report->shouldReceive('fromNamedError')

--- a/tests/BugsnagLoggerTest.php
+++ b/tests/BugsnagLoggerTest.php
@@ -28,7 +28,7 @@ class BugsnagLoggerTest extends TestCase
         $exception = new Exception();
 
         $config = Mockery::mock(Configuration::class);
-        $config->logThreshold = null;
+        $config->logLevel = null;
         $config->logWarningLevel = null;
         $config->logErrorLevel = null;
 
@@ -55,7 +55,7 @@ class BugsnagLoggerTest extends TestCase
         $exception = new Exception();
         
         $config = Mockery::mock(Configuration::class);
-        $config->logThreshold = null;
+        $config->logLevel = null;
         $config->logWarningLevel = null;
         $config->logErrorLevel = null;
 
@@ -82,7 +82,7 @@ class BugsnagLoggerTest extends TestCase
         $exception = new Exception();
 
         $config = Mockery::mock(Configuration::class);
-        $config->logThreshold = null;
+        $config->logLevel = null;
         $config->logWarningLevel = null;
         $config->logErrorLevel = null;
 
@@ -107,7 +107,7 @@ class BugsnagLoggerTest extends TestCase
     public function testInfo()
     {
         $config = Mockery::mock(Configuration::class);
-        $config->logThreshold = null;
+        $config->logLevel = null;
         $config->logWarningLevel = null;
         $config->logErrorLevel = null;
 
@@ -125,7 +125,7 @@ class BugsnagLoggerTest extends TestCase
     public function testDebug()
     {
         $config = Mockery::mock(Configuration::class);
-        $config->logThreshold = null;
+        $config->logLevel = null;
         $config->logWarningLevel = null;
         $config->logErrorLevel = null;
 
@@ -145,7 +145,7 @@ class BugsnagLoggerTest extends TestCase
         $exception = new Exception();
 
         $config = Mockery::mock(Configuration::class);
-        $config->logThreshold = null;
+        $config->logLevel = null;
         $config->logWarningLevel = null;
         $config->logErrorLevel = null;
         
@@ -165,5 +165,84 @@ class BugsnagLoggerTest extends TestCase
 
         $logger = new BugsnagLogger($client);
         $logger->alert('hi!', ['foo' => 'baz']);
+    }
+
+    public function testLogLevel()
+    {
+        $config = Mockery::mock(Configuration::class);
+        $config->logLevel = 'error';
+        $config->logWarningLevel = null;
+        $config->logErrorLevel = null;
+
+        $report = Mockery::namedMock('Bugsnag\Report', ReportStub::class);
+        $report->shouldReceive('fromNamedError')
+            ->with($config, Mockery::any(), Mockery::any())
+            ->once()
+            ->andReturn($report);
+        $report->shouldReceive('setMetaData')->once()->with(Mockery::any());
+        $report->shouldReceive('setSeverity')->once()->with('error');
+        $report->shouldReceive('setSeverityReason')->once()->with(['type' => 'log', 'attributes' => ['level' => 'error']]);
+
+        $client = Mockery::mock(Client::class);
+        $client->shouldReceive('getConfig')->andReturn($config);
+        $client->shouldReceive('notify')->once()->with($report);
+        $client->shouldReceive('leaveBreadcrumb')
+            ->once()
+            ->withArgs(['Log warning', 'log', ['foo' => 'baz', 'message' => 'hi']]);
+
+        $logger = new BugsnagLogger($client);
+        $logger->warning('hi', ['foo' => 'baz']);
+
+        $logger->error('hi', ['bar' => 'fuu']);
+    }
+
+    public function testWarningLevel()
+    {
+        $config = Mockery::mock(Configuration::class);
+        $config->logLevel = null;
+        $config->logWarningLevel = 'notice';
+        $config->logErrorLevel = null;
+
+        $report = Mockery::namedMock('Bugsnag\Report', ReportStub::class);
+        $report->shouldReceive('fromNamedError')
+            ->with($config, Mockery::any(), Mockery::any())
+            ->once()
+            ->andReturn($report);
+        $report->shouldReceive('setMetaData')->once()->with(Mockery::any());
+        $report->shouldReceive('setSeverity')->once()->with('warning');
+        $report->shouldReceive('setSeverityReason')->once()->with(['type' => 'log', 'attributes' => ['level' => 'notice']]);
+
+        $client = Mockery::mock(Client::class);
+        $client->shouldReceive('getConfig')->andReturn($config);
+        $client->shouldReceive('notify')->once()->with($report);
+        $client->shouldNotReceive('leaveBreadcrumb');
+
+        $logger = new BugsnagLogger($client);
+        $logger->notice('notice', ['type' => 'notice']);
+    }
+
+    public function testErrorLevel()
+    {
+        $config = Mockery::mock(Configuration::class);
+        $config->logLevel = null;
+        $config->logWarningLevel = null;
+        $config->logErrorLevel = 'warning';
+
+        $report = Mockery::namedMock('Bugsnag\Report', ReportStub::class);
+        $report->shouldReceive('fromNamedError')
+            ->with($config, Mockery::any(), Mockery::any())
+            ->once()
+            ->andReturn($report);
+        $report->shouldReceive('setMetaData')->once()->with(Mockery::any());
+        $report->shouldReceive('setSeverity')->once()->with('error');
+        $report->shouldReceive('setSeverityReason')->once()->with(['type' => 'log', 'attributes' => ['level' => 'warning']]);
+
+        $client = Mockery::mock(Client::class);
+        $client->shouldReceive('getConfig')->andReturn($config);
+        $client->shouldReceive('notify')->once()->with($report);
+        $client->shouldNotReceive('leaveBreadcrumb');
+
+        $logger = new BugsnagLogger($client);
+        $logger->warning('warning', ['type' => 'warning']);
     }
 }

--- a/tests/BugsnagLoggerTest.php
+++ b/tests/BugsnagLoggerTest.php
@@ -51,7 +51,7 @@ class BugsnagLoggerTest extends TestCase
     public function testContextExceptionOverride()
     {
         $exception = new Exception();
-        
+
         $config = Mockery::mock(Configuration::class);
         $config->shouldReceive('getLogLevel')->andReturn(null);
 
@@ -68,7 +68,7 @@ class BugsnagLoggerTest extends TestCase
         $client->shouldReceive('getConfig')->andReturn($config);
         $client->shouldReceive('notify')->once()->with($report);
         $client->shouldNotReceive('leaveBreadcrumb');
-        
+
         $logger = new BugsnagLogger($client);
         $logger->log('error', 'terrible things!', ['exception' => $exception]);
     }
@@ -133,52 +133,102 @@ class BugsnagLoggerTest extends TestCase
     public function testAlert()
     {
         $exception = new Exception();
+        $config = Mockery::mock(Configuration::class)->makePartial();
+        $client = Mockery::mock(Client::class)->makePartial();
 
-        $config = Mockery::mock(Configuration::class);
-        $config->shouldReceive('getLogLevel')->andReturn(null);
-        
-        $report = Mockery::namedMock('Bugsnag\Report', ReportStub::class);
-        $report->shouldReceive('fromNamedError')
-            ->with($config, Mockery::any(), Mockery::any())
-            ->once()
-            ->andReturn($report);
-        $report->shouldReceive('setMetaData')->once()->with(Mockery::any());
-        $report->shouldReceive('setSeverity')->once()->with('error');
-        $report->shouldReceive('setSeverityReason')->once()->with(['type' => 'log', 'attributes' => ['level' => 'alert']]);
-
-        $client = Mockery::mock(Client::class);
         $client->shouldReceive('getConfig')->andReturn($config);
-        $client->shouldReceive('notify')->once()->with($report);
         $client->shouldNotReceive('leaveBreadcrumb');
+        $client->shouldReceive('notify')->once()
+            ->andReturnUsing(function ($report) {
+                $this->assertSameInBlock('error', $report->getSeverity());
+                $this->assertSameInBlock('hi!', $report->getMessage());
+                $this->assertSameInBlock('Log alert', $report->getName());
+                $this->assertSameInBlock('log', $report->getSeverityReason()['type']);
+                $this->assertSameInBlock('alert', $report->getSeverityReason()['attributes']['level']);
+                $this->assertSameInBlock('baz', $report->getMetaData()['foo']);
+            });
 
         $logger = new BugsnagLogger($client);
         $logger->alert('hi!', ['foo' => 'baz']);
     }
 
-    public function testLogLevel()
+    public function testSetNotifyLevel()
     {
-        $config = Mockery::mock(Configuration::class);
-        $config->shouldReceive('getLogLevel')->andReturn('error');
-
-        $report = Mockery::namedMock('Bugsnag\Report', ReportStub::class);
-        $report->shouldReceive('fromNamedError')
-            ->with($config, Mockery::any(), Mockery::any())
-            ->once()
-            ->andReturn($report);
-        $report->shouldReceive('setMetaData')->once()->with(Mockery::any());
-        $report->shouldReceive('setSeverity')->once()->with('error');
-        $report->shouldReceive('setSeverityReason')->once()->with(['type' => 'log', 'attributes' => ['level' => 'error']]);
-
-        $client = Mockery::mock(Client::class);
+        $config = Mockery::mock(Configuration::class)->makePartial();
+        $client = Mockery::mock(Client::class)->makePartial();
         $client->shouldReceive('getConfig')->andReturn($config);
-        $client->shouldReceive('notify')->once()->with($report);
+
+        $logger = new BugsnagLogger($client);
+        $logger->setNotifyLevel(\Psr\Log\LogLevel::ERROR);
+
+        $client->shouldReceive('notify')->once()
+            ->andReturnUsing(function ($report) {
+                $this->assertSameInBlock('error', $report->getSeverity());
+                $this->assertSameInBlock('Log alert', $report->getName());
+                $this->assertSameInBlock('log', $report->getSeverityReason()['type']);
+                $this->assertSameInBlock('alert', $report->getSeverityReason()['attributes']['level']);
+                $this->assertSameInBlock('fuu', $report->getMetaData()['bar']);
+            });
+        $logger->alert('hi', ['bar' => 'fuu']);
+
+        $client->shouldReceive('notify')->once()
+            ->andReturnUsing(function ($report) {
+                $this->assertSameInBlock('error', $report->getSeverity());
+                $this->assertSameInBlock('Log emergency', $report->getName());
+                $this->assertSameInBlock('log', $report->getSeverityReason()['type']);
+                $this->assertSameInBlock('emergency', $report->getSeverityReason()['attributes']['level']);
+                $this->assertSameInBlock('fii', $report->getMetaData()['bar']);
+            });
+        $logger->emergency('hi', ['bar' => 'fii']);
+
+        $client->shouldReceive('notify')->once()
+            ->andReturnUsing(function ($report) {
+                $this->assertSameInBlock('error', $report->getSeverity());
+                $this->assertSameInBlock('Log critical', $report->getName());
+                $this->assertSameInBlock('log', $report->getSeverityReason()['type']);
+                $this->assertSameInBlock('critical', $report->getSeverityReason()['attributes']['level']);
+                $this->assertSameInBlock('foo', $report->getMetaData()['bar']);
+            });
+        $logger->critical('hi', ['bar' => 'foo']);
+
+        $client->shouldReceive('notify')->once()
+            ->andReturnUsing(function ($report) {
+                $this->assertSameInBlock('error', $report->getSeverity());
+                $this->assertSameInBlock('Log error', $report->getName());
+                $this->assertSameInBlock('log', $report->getSeverityReason()['type']);
+                $this->assertSameInBlock('error', $report->getSeverityReason()['attributes']['level']);
+                $this->assertSameInBlock('faa', $report->getMetaData()['bar']);
+            });
+        $logger->error('hi', ['bar' => 'faa']);
+
         $client->shouldReceive('leaveBreadcrumb')
             ->once()
             ->withArgs(['Log warning', 'log', ['foo' => 'baz', 'message' => 'hi']]);
-
-        $logger = new BugsnagLogger($client);
         $logger->warning('hi', ['foo' => 'baz']);
 
-        $logger->error('hi', ['bar' => 'fuu']);
+        $client->shouldReceive('leaveBreadcrumb')
+            ->once()
+            ->withArgs(['Log notice', 'log', ['foo' => 'baz', 'message' => 'hi']]);
+        $logger->notice('hi', ['foo' => 'baz']);
+
+        $client->shouldReceive('leaveBreadcrumb')
+            ->once()
+            ->withArgs(['Log debug', 'log', ['foo' => 'baz', 'message' => 'hi']]);
+        $logger->debug('hi', ['foo' => 'baz']);
+
+        $client->shouldReceive('leaveBreadcrumb')
+            ->once()
+            ->withArgs(['Log info', 'log', ['foo' => 'baz', 'message' => 'hi']]);
+        $logger->info('hi', ['foo' => 'baz']);
+    }
+
+    /**
+     * Makeshift assertion to ensure test context not lost within closures.
+     */
+    private function assertSameInBlock($expected, $actual)
+    {
+        if ($expected != $actual) {
+            throw new Exception("Expected '".$expected."' received '".$actual."'");
+        }
     }
 }

--- a/tests/MultiLoggerTest.php
+++ b/tests/MultiLoggerTest.php
@@ -2,7 +2,6 @@
 
 namespace Bugsnag\PsrLogger;
 
-use Bugsnag\PsrLogger\MultiLogger;
 use GrahamCampbell\TestBenchCore\MockeryTrait;
 use Mockery;
 use PHPUnit_Framework_TestCase as TestCase;

--- a/tests/MultiLoggerTest.php
+++ b/tests/MultiLoggerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Bugsnag\PsrLogger\Tests;
+namespace Bugsnag\PsrLogger;
 
 use Bugsnag\PsrLogger\MultiLogger;
 use GrahamCampbell\TestBenchCore\MockeryTrait;


### PR DESCRIPTION
This adds 3 new configuration options obtained through the Bugsnag-php config object for:
- NotifyLevel: The LogLevel at which notifications will be sent to bugsnag
- WarningLevel: The LogLevel at which notifications will be given a severity "warning"
- ErrorLevel: The LogLevel at which notifications will be given a severity "error"

This requires an update of the PHP notifier and a dependency update before it can be merged.