### PR TITLE
Ensured all log levels are present

### DIFF
--- a/src/BugsnagLogger.php
+++ b/src/BugsnagLogger.php
@@ -134,6 +134,7 @@ class BugsnagLogger extends AbstractLogger
             LogLevel::DEBUG,
             LogLevel::INFO,
             LogLevel::NOTICE,
+            LogLevel::WARNING,
             LogLevel::ERROR,
             LogLevel::CRITICAL,
             LogLevel::ALERT,


### PR DESCRIPTION
Adds `LogLevel::WARNING` back into the log level hierarchy ensuring these logs are notified correctly.