### PR TITLE
split responsibilities for log() and may set unhandledException

### DIFF
--- a/src/BugsnagLogger.php
+++ b/src/BugsnagLogger.php
@@ -210,6 +210,11 @@ class BugsnagLogger extends AbstractLogger
             ],
         ]);
 
+        if (isset($this->context['unhandledException']) && is_bool($this->context['unhandledException'])) {
+            $report->setUnhandled($this->context['unhandledException']);
+            unset($this->context['unhandledException']);
+        }
+
         return $report;
     }
 


### PR DESCRIPTION
-  refactor: split responsibilities for log() method. This way a user can override some behaviour (e.g.
`$report->setUnhandled(true)`)

- feature: may set unhandledException attribute in the Report. The key 'unhandledException' in log's $context will be used to set the unhandledException attribute in the Report.