### PR TITLE
Fix warnings being set with error severity in event

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ sudo: false
 matrix:
   include:
     - php: 5.5.9
+      dist: trusty
     - php: 5.5
+      dist: trusty
     - php: 5.6
     - php: 7.0
     - php: 7.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fix warnings being set with error severity in event (fixes [#35](https://github.com/bugsnag/bugsnag-psr-logger/issues/35))
+[#37](https://github.com/bugsnag/bugsnag-psr-logger/pull/37)
+
 ## 1.4.1 (2018-02-16)
 
 ### Bug fixes

--- a/src/BugsnagLogger.php
+++ b/src/BugsnagLogger.php
@@ -160,12 +160,12 @@ class BugsnagLogger extends AbstractLogger
      */
     protected function getSeverity($level)
     {
-        if (!$this->aboveLevel($level, 'notice')) {
-            return 'info';
-        } elseif (!$this->aboveLevel($level, 'warning')) {
+        if ($this->aboveLevel($level, 'error')) {
+            return 'error';
+        } elseif ($this->aboveLevel($level, 'warning')) {
             return 'warning';
         } else {
-            return 'error';
+            return 'info';
         }
     }
 


### PR DESCRIPTION
## Goal

As per #35, the comparison of log levels is incorrect for warnings and results in them being set with `error` severity.

## Changeset

### Changed

* BugsnagLogger.php - reversed the logic as the `aboveLevel` method is a little misleadingly name and really means "at or above level".

## Tests

* Extra unit test introduced for the warning case.

### Linked issues

Fixes #35 and bugsnag/bugsnag-laravel#349

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
