### PR TITLE
Add support for PSR Log v2

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -11,6 +11,10 @@ jobs:
         php-version: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
         psr-log-version: ['^1.0']
 
+        include:
+          - php-version: '8.0'
+            psr-log-version: '^2.0'
+
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0 ]
+        php-version: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -9,6 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         php-version: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
+        psr-log-version: ['^1.0']
 
     steps:
     - uses: actions/checkout@v2
@@ -19,6 +20,8 @@ jobs:
         php-version: ${{ matrix.php-version }}
 
     - run: composer validate
+
+    - run: composer require psr/log:${{ matrix.psr-log-version }} --no-update
 
     - name: install dependencies
       run: composer update --prefer-dist --no-progress --no-interaction ${{ matrix.composer-flags }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+## 1.4.4 (TBD)
+
+* Added support for PSR Log v2
+  [#46](https://github.com/bugsnag/bugsnag-psr-logger/pull/46)
+
 ## 1.4.3 (2020-02-26)
 
 ### Bug fixes

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.5",
         "bugsnag/bugsnag": "^3.10",
-        "psr/log": "^1.0"
+        "psr/log": "^1.0|^2.0"
     },
     "require-dev": {
         "graham-campbell/testbench-core": "^1.1",


### PR DESCRIPTION
## Goal

PSR Log v2 adds a `string|\Stringable` type to the `$message` parameter

Due to PHP's support for contravariant parameters ([added in PHP 7.4 vis this RFC](https://wiki.php.net/rfc/covariant-returns-and-contravariant-parameters)) and PSR Log's requirement for PHP 8.0, we are actually already compatible with this change

This PR adds PSR Log v2 to CI and as an allowed version in our composer.json

PSR Log v3 requires additional changes, so will be handled separately