### PR TITLE
Prevent leaving breadcrumbs when log is below a certain level

### DIFF
--- a/tests/BugsnagLoggerTest.php
+++ b/tests/BugsnagLoggerTest.php
@@ -197,6 +197,7 @@ class BugsnagLoggerTest extends TestCase
 
         $logger = new BugsnagLogger($client);
         $logger->setNotifyLevel(\Psr\Log\LogLevel::ERROR);
+        $logger->setBreadcrumbLevel(\Psr\Log\LogLevel::INFO);
 
         $client->shouldReceive('notify')->once()
             ->andReturnUsing(function ($report) {
@@ -248,9 +249,7 @@ class BugsnagLoggerTest extends TestCase
             ->withArgs(['Log notice', 'log', ['foo' => 'baz', 'message' => 'hi']]);
         $logger->notice('hi', ['foo' => 'baz']);
 
-        $client->shouldReceive('leaveBreadcrumb')
-            ->once()
-            ->withArgs(['Log debug', 'log', ['foo' => 'baz', 'message' => 'hi']]);
+        $client->shouldNotReceive('leaveBreadcrumb');
         $logger->debug('hi', ['foo' => 'baz']);
 
         $client->shouldReceive('leaveBreadcrumb')


### PR DESCRIPTION
## Goal

Currently anything that is below the notify level gets added as a breadcrumb on a log that is notifiable. In one of our apps we use debug logs extensively during development, but don't expect these to be logged on a production environment at all, because they can contain sensitive data.

The intention of the `breadcrumbLevel` is to set a minimum level of a log message for it to be added as a breadcrumb.

## Design

I have kept it in line with the existing `notifyLevel` property and `setNotifyLevel` method. The default for the `breadcrumbLevel` is `DEBUG`. Unless explicitly changed, functionally nothing with change for existing users.

## Testing

Existing test was modified to set the minimum breadcrumb level to INFO, causing the DEBUG log that was there not to trigger the `leaveBreadcrumb` method.